### PR TITLE
ci(mac-build): 更新 macOS 构建工作流以支持 M1 架构

### DIFF
--- a/.github/workflows/mac-build.yaml
+++ b/.github/workflows/mac-build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge  # 更改为支持 M1 的运行器
     permissions:
       contents: write
       packages: write
@@ -25,6 +25,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+          target: aarch64-apple-darwin  # 添加 ARM 架构支持
 
       - name: 📦 安装系统依赖
         run: |
@@ -51,20 +52,20 @@ jobs:
 
       - name: 🛠️ 构建 macOS 应用
         run: |
-          flutter build macos --release
+          flutter build macos --release --target-platform=darwin-arm64  # 指定 ARM64 平台
 
       - name: 📦 打包应用
         run: |
           mkdir -p release
           cd build/macos/Build/Products/Release
           # 创建 DMG 文件
-          hdiutil create -volname "Astral" -srcfolder astral.app -ov -format UDZO $GITHUB_WORKSPACE/release/astral-macos.dmg
+          hdiutil create -volname "Astral" -srcfolder astral.app -ov -format UDZO $GITHUB_WORKSPACE/release/astral-macos-arm64.dmg
           echo "打包完成，检查文件大小："
           ls -lh $GITHUB_WORKSPACE/release/
 
       - name: 📤 上传构建产物
         uses: actions/upload-artifact@v4
         with:
-          name: macos-release
-          path: release/astral-macos.dmg
+          name: macos-arm64-release
+          path: release/astral-macos-arm64.dmg
           retention-days: 7


### PR DESCRIPTION
修改运行器为 macos-latest-xlarge 以支持 M1 芯片，并添加 ARM64 架构的构建目标。同时更新打包和上传步骤以区分 ARM64 构建产物。