### PR TITLE
更改工作流，降低Linux 打包平台，以支持Ubuntu22 x86

### DIFF
--- a/.github/workflows/linux-build.yaml
+++ b/.github/workflows/linux-build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
降低Linux 打包平台，以支持amd64 Ubuntu22,debian 12。
因为glic的 问题，24 的打包结果，无法给22使用。
会出现
```bash
./astral 
./astral: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /home/archon_linux/Downloads/astral-linux-x64/lib/librust_lib_astral.so)
```
而22 可以给24 使用。
因此适当降低了平台，以提高兼容性。