### PR TITLE
修复（Windows）：修正faketcp回退接口并改进错误处理

### DIFF
--- a/rust/easytier/src/tunnel/fake_tcp/netfilter/mod.rs
+++ b/rust/easytier/src/tunnel/fake_tcp/netfilter/mod.rs
@@ -53,22 +53,39 @@ cfg_if::cfg_if! {
         pub mod windivert;
 
         pub fn create_tun(
-            _interface_name: &str,
-            _src_addr: Option<SocketAddr>,
+            interface_name: &str,
+            src_addr: Option<SocketAddr>,
             local_addr: SocketAddr,
         ) -> io::Result<Arc<dyn super::stack::Tun>> {
             match windivert::WinDivertTun::new(local_addr) {
                 Ok(tun) => Ok(Arc::new(tun)),
-                Err(e) => {
+                Err(windivert_err) => {
                     tracing::warn!(
-                        ?e,
+                        ?windivert_err,
+                        interface_name,
                         ?local_addr,
                         "WinDivertTun init failed, falling back to PnetTun"
                     );
-                    Ok(Arc::new(pnet::PnetTun::new(
-                        local_addr.to_string().as_str(),
-                        pnet::create_packet_filter(None, local_addr),
-                    )?))
+
+                    if interface_name.is_empty() {
+                        return Err(io::Error::other(format!(
+                            "WinDivert init failed ({windivert_err}); fallback requires a valid network interface name"
+                        )));
+                    }
+
+                    pnet::PnetTun::new(
+                        interface_name,
+                        pnet::create_packet_filter(src_addr, local_addr),
+                    )
+                        .map(|tun| Arc::new(tun) as Arc<dyn super::stack::Tun>)
+                        .map_err(|pnet_err| {
+                            io::Error::new(
+                                pnet_err.kind(),
+                                format!(
+                                    "WinDivert init failed ({windivert_err}); fallback PnetTun failed on interface '{interface_name}' ({pnet_err})"
+                                ),
+                            )
+                        })
                 }
             }
         }


### PR DESCRIPTION
Title:
fix(windows): correct faketcp fallback interface and improve error handling

## Background

在 Windows 平台上现有的 faketcp fallback 实现存在两个问题：
- 使用的网络接口名称不准确，导致 fallback 逻辑无法触发
- 错误信息和过滤参数不够明确，难以定位 faketcp 失败原因

这些问题造成 faketcp 功能不稳定，从而影响了在 Windows 上的连接可靠性。

## Changes

- 将 faketcp fallback 使用的 interface identifier 改为更准确的名称/匹配规则
- 精炼并增强过滤参数逻辑，避免误判
- 改善错误日志输出，使失败原因更清晰

## Impact

仅影响 Windows 下的 faketcp fallback 实现，不会改变其它平台行为；
不影响主逻辑或核心网络引擎。

## Verification

- 在 Windows 环境中复现 faketcp fallback 失败场景
- 确认 fallback 能正确触发并建立连接
- 验证对应错误日志输出能反映真实失败原因

## Risk

低风险，本次变更范围局部且不涉及跨平台逻辑。
