### PR TITLE
Update Cargo.toml to add support for tls1.2 when use wss

### DIFF
--- a/rust/easytier/Cargo.toml
+++ b/rust/easytier/Cargo.toml
@@ -67,7 +67,7 @@ pin-project-lite = "0.2.13"
 quinn = { version = "0.11.8", optional = true, features = ["ring"] }
 
 rustls = { version = "0.23.0", features = [
-    "ring",
+    "ring","tls12"
 ], default-features = false, optional = true }
 rcgen = { version = "0.12.1", optional = true }
 


### PR DESCRIPTION
当rultls没有使用tls12特性构建时，easytier使用wss连接服务器时，仅支持tls1.3加密套件。此时若wss反向代理不支持tls1.3，便会连接失败。通过添加tls12特性，easytier使用wss连接服务器时，可以同时支持tls1.2和tls1.3。