### PR TITLE
fix: stop ConnectButton animation when idle to reduce GPU usage

### DIFF
--- a/lib/shared/widgets/common/home/connect_button.dart
+++ b/lib/shared/widgets/common/home/connect_button.dart
@@ -34,7 +34,7 @@ class _ConnectButtonState extends State<ConnectButton>
     _animationController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 800),
-    )..repeat(reverse: true);
+    );
 
     // 初始化服务
     if (Platform.isAndroid) {
@@ -303,6 +303,18 @@ class _ConnectButtonState extends State<ConnectButton>
       child: Watch((context) {
         final connectionState = ServiceManager().connectionState.connectionState
             .watch(context);
+
+        // 管理动画：仅在连接中时运行动画，其他状态停止
+        if (connectionState == CoState.connecting) {
+          if (!_animationController.isAnimating) {
+            _animationController.repeat(reverse: true);
+          }
+        } else {
+          if (_animationController.isAnimating) {
+            _animationController.stop();
+            _animationController.reset();
+          }
+        }
 
         return Padding(
           padding: const EdgeInsets.all(16.0),


### PR DESCRIPTION
The AnimationController was running repeat(reverse: true) continuously from initState, causing constant GPU/CPU usage even when the app was idle. The rotation animation is only needed during the connecting state.

Changes:
- Remove continuous repeat from initState
- Add animation control logic in build method
- Only animate when connectionState == CoState.connecting
- Stop and reset animation when not connecting

Fixes ldoubil/astral#192