### PR TITLE
修复：Android VPN 子网代理路由未生效的问题

### DIFF
--- a/lib/core/services/server_connection_manager.dart
+++ b/lib/core/services/server_connection_manager.dart
@@ -422,9 +422,27 @@ class ServerConnectionManager {
     });
 
     if (Platform.isAndroid) {
+      // 主动获取网络状态，确保能拿到子网代理路由
+      List<String> proxyCidrs = [];
+      try {
+        final netStatus = await getNetworkStatus();
+        ServiceManager().connectionState.netStatus.value = netStatus;
+        for (final node in netStatus.nodes) {
+          for (final cidr in node.proxyCidrs) {
+            if (isValidCIDR(cidr) && !proxyCidrs.contains(cidr)) {
+              proxyCidrs.add(cidr);
+            }
+          }
+        }
+      } catch (_) {
+        // 如果获取失败，回退到从 state 中读取
+        proxyCidrs = _extractProxyCidrs();
+      }
+
       await VpnManager.instance.start(
         ipv4Addr: ServiceManager().networkConfigState.ipv4.value,
         mtu: ServiceManager().networkConfigState.mtu.value,
+        proxyCidrs: proxyCidrs,
       );
 
       if (ServiceManager().appSettingsState.enableConnectionNotification.value) {
@@ -472,9 +490,23 @@ class ServerConnectionManager {
 
       try {
         final netStatus = await getNetworkStatus();
+        final previousProxyCidrs = _extractProxyCidrs();
         batch(() {
           ServiceManager().connectionState.netStatus.value = netStatus;
         });
+
+        // 当 peer 子网代理路由发生变化时，刷新 Android VPN 路由。
+        if (Platform.isAndroid) {
+          final currentProxyCidrs = _extractProxyCidrs();
+          if (currentProxyCidrs.toSet().difference(previousProxyCidrs.toSet()).isNotEmpty ||
+              previousProxyCidrs.toSet().difference(currentProxyCidrs.toSet()).isNotEmpty) {
+            await VpnManager.instance.start(
+              ipv4Addr: ServiceManager().networkConfigState.ipv4.value,
+              mtu: ServiceManager().networkConfigState.mtu.value,
+              proxyCidrs: currentProxyCidrs,
+            );
+          }
+        }
       } catch (_) {
         // Notification updates should continue even if network stats fail.
       }
@@ -498,6 +530,22 @@ class ServerConnectionManager {
     } finally {
       _isMonitoringNetwork = false;
     }
+  }
+
+  /// 从网络状态中提取子网代理路由
+  List<String> _extractProxyCidrs() {
+    final netStatus = ServiceManager().connectionState.netStatus.value;
+    if (netStatus == null) return [];
+
+    final cidrs = <String>[];
+    for (final node in netStatus.nodes) {
+      for (final cidr in node.proxyCidrs) {
+        if (isValidCIDR(cidr) && !cidrs.contains(cidr)) {
+          cidrs.add(cidr);
+        }
+      }
+    }
+    return cidrs;
   }
 
   /// 提取IPv4地址

--- a/lib/core/services/vpn_manager.dart
+++ b/lib/core/services/vpn_manager.dart
@@ -36,6 +36,7 @@ class VpnManager {
     required String ipv4Addr,
     int mtu = 1300,
     List<String> disallowedApplications = const ['com.kevin.astral'],
+    List<String> proxyCidrs = const [],
   }) async {
     final plugin = _plugin;
     if (plugin == null) return;
@@ -48,10 +49,13 @@ class VpnManager {
     }
 
     // 获取有效的VPN路由
-    final routes =
+    final customRoutes =
         ServiceManager().vpnState.customVpn.value
             .where((route) => isValidCIDR(route))
             .toList();
+    
+    // 合并自定义路由和子网代理路由
+    final routes = [...customRoutes, ...proxyCidrs.where((route) => isValidCIDR(route))];
 
     await plugin.startVpn(
       ipv4Addr: finalIpv4,

--- a/lib/src/rust/api/simple.dart
+++ b/lib/src/rust/api/simple.dart
@@ -291,6 +291,7 @@ class KVNodeInfo {
   final BigInt txBytes;
   final String version;
   final int cost;
+  final List<String> proxyCidrs;
 
   const KVNodeInfo({
     required this.peerId,
@@ -307,6 +308,7 @@ class KVNodeInfo {
     required this.txBytes,
     required this.version,
     required this.cost,
+    this.proxyCidrs = const [],
   });
 
   @override
@@ -324,7 +326,8 @@ class KVNodeInfo {
       rxBytes.hashCode ^
       txBytes.hashCode ^
       version.hashCode ^
-      cost.hashCode;
+      cost.hashCode ^
+      proxyCidrs.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -344,7 +347,8 @@ class KVNodeInfo {
           rxBytes == other.rxBytes &&
           txBytes == other.txBytes &&
           version == other.version &&
-          cost == other.cost;
+          cost == other.cost &&
+          proxyCidrs == other.proxyCidrs;
 }
 
 class NodeHopStats {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -2898,8 +2898,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   KVNodeInfo dco_decode_kv_node_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 14)
-      throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
+    if (arr.length != 15)
+      throw Exception('unexpected arr length: expect 15 but see ${arr.length}');
     return KVNodeInfo(
       peerId: dco_decode_u_32(arr[0]),
       hostname: dco_decode_String(arr[1]),
@@ -2915,6 +2915,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       txBytes: dco_decode_u_64(arr[11]),
       version: dco_decode_String(arr[12]),
       cost: dco_decode_i_32(arr[13]),
+      proxyCidrs: dco_decode_list_String(arr[14]),
     );
   }
 
@@ -3572,6 +3573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_txBytes = sse_decode_u_64(deserializer);
     var var_version = sse_decode_String(deserializer);
     var var_cost = sse_decode_i_32(deserializer);
+    var var_proxyCidrs = sse_decode_list_String(deserializer);
     return KVNodeInfo(
       peerId: var_peerId,
       hostname: var_hostname,
@@ -3587,6 +3589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       txBytes: var_txBytes,
       version: var_version,
       cost: var_cost,
+      proxyCidrs: var_proxyCidrs,
     );
   }
 
@@ -4306,6 +4309,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_64(self.txBytes, serializer);
     sse_encode_String(self.version, serializer);
     sse_encode_i_32(self.cost, serializer);
+    sse_encode_list_String(self.proxyCidrs, serializer);
   }
 
   @protected

--- a/rust/src/api/p2p.rs
+++ b/rust/src/api/p2p.rs
@@ -726,6 +726,7 @@ pub async fn get_network_status(instance_id: String) -> KVNetworkStatus {
                     .to_string(),
                 rx_bytes: pair.get_rx_bytes().unwrap_or_default(),
                 tx_bytes: pair.get_tx_bytes().unwrap_or_default(),
+                proxy_cidrs: route.proxy_cidrs.clone(),
             };
 
             if let Some(peer) = &pair.peer {

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -274,6 +274,7 @@ pub struct KVNodeInfo {
 
     pub version: String,
     pub cost: i32,
+    pub proxy_cidrs: Vec<String>,
 }
 // 定义节点网络状态结构体
 pub struct KVNetworkStatus {
@@ -928,6 +929,7 @@ pub async fn get_network_status() -> KVNetworkStatus {
                     .to_string(),
                 rx_bytes: pair.get_rx_bytes().unwrap_or_default(),
                 tx_bytes: pair.get_tx_bytes().unwrap_or_default(),
+                proxy_cidrs: route.proxy_cidrs.clone(),
             };
 
             // 收集连接统计信息

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2918,6 +2918,7 @@ impl SseDecode for crate::api::simple::KVNodeInfo {
         let mut var_txBytes = <u64>::sse_decode(deserializer);
         let mut var_version = <String>::sse_decode(deserializer);
         let mut var_cost = <i32>::sse_decode(deserializer);
+        let mut var_proxyCidrs = <Vec<String>>::sse_decode(deserializer);
         return crate::api::simple::KVNodeInfo {
             peer_id: var_peerId,
             hostname: var_hostname,
@@ -2933,6 +2934,7 @@ impl SseDecode for crate::api::simple::KVNodeInfo {
             tx_bytes: var_txBytes,
             version: var_version,
             cost: var_cost,
+            proxy_cidrs: var_proxyCidrs,
         };
     }
 }
@@ -3729,6 +3731,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::simple::KVNodeInfo {
             self.tx_bytes.into_into_dart().into_dart(),
             self.version.into_into_dart().into_dart(),
             self.cost.into_into_dart().into_dart(),
+            self.proxy_cidrs.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -4159,6 +4162,7 @@ impl SseEncode for crate::api::simple::KVNodeInfo {
         <u64>::sse_encode(self.tx_bytes, serializer);
         <String>::sse_encode(self.version, serializer);
         <i32>::sse_encode(self.cost, serializer);
+        <Vec<String>>::sse_encode(self.proxy_cidrs, serializer);
     }
 }
 


### PR DESCRIPTION
## 问题

连接到开启了子网代理的 EasyTier 网络时，Android VPN TUN 接口没有将代理子网（如 `192.168.1.0/24`）加入路由表，导致无法访问代理子网后的设备。

## 根因

1. Rust 的 `KVNodeInfo` 结构体缺少 `proxy_cidrs` 字段
2. Dart 层无法获取对等节点的子网代理信息
3. `VpnManager.start()` 未接收代理路由参数
4. `_handleSuccessfulConnection()` 在 `netStatus` 尚未填充时就调用 `_extractProxyCidrs()$，导致路由列表为空

## 修改内容

### Rust
- `rust/src/api/simple.rs`: `KVNodeInfo` 添加 `proxy_cidrs: Vec<String>` 字段
- `rust/src/api/p2p.rs`: `get_network_status()` 从 `node_info.proxy_cidrs` 填充数据
- `rust/src/frb_generated.rs`: 更新 FRB 序列化代码

### Dart
- `lib/src/rust/api/simple.dart`: `KVNodeInfo` 添加 `proxyCidrs` 字段
- `lib/src/rust/frb_generated.dart`: 更新 FRB 序列化代码
- `lib/core/services/vpn_manager.dart`: `start()` 方法新增 `List<String> proxyCidrs` 参数
- `lib/core/services/server_connection_manager.dart`: 连接成功后主动调用 `getNetworkStatus()` 提取对等节点的 `proxyCidrs`，并传入 VPN 服务

## 测试方法

1. 连接到一个有节点宣告 `192.168.1.0/24` 子网代理的 EasyTier 网络
2. 确认 VPN 连接成功
3. 确认可以访问 `192.168.1.x` 网段的设备

Fixes #216