### PR TITLE
[codex] 优化 Windows 自启动方式

### DIFF
--- a/lib/core/platform/startup_url_scheme.dart
+++ b/lib/core/platform/startup_url_scheme.dart
@@ -1,9 +1,10 @@
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 
-const _startupRunKey =
-    'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run';
-const _startupValueName = 'Astral';
+const _taskName = 'Astral';
+
+/// 由 main.dart 在启动时设置，标记当前是否为自动启动
+bool isAutostart = false;
 
 Future<void> _removeLegacyStartupShortcut() async {
   if (!Platform.isWindows) return;
@@ -23,6 +24,21 @@ Future<void> _removeLegacyStartupShortcut() async {
   }
 }
 
+/// 移除旧的注册表 Run 键（如果存在），迁移到 Task Scheduler 方案
+Future<void> _removeLegacyRegistryRun() async {
+  try {
+    await Process.run('reg', [
+      'delete',
+      'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run',
+      '/v',
+      'Astral',
+      '/f',
+    ]);
+  } catch (_) {
+    // 旧键可能不存在，忽略错误
+  }
+}
+
 Future<void> handleStartupSetting(bool enable) async {
   if (!Platform.isWindows) return;
 
@@ -30,32 +46,34 @@ Future<void> handleStartupSetting(bool enable) async {
   final command = '"$executablePath" --autostart';
 
   await _removeLegacyStartupShortcut();
+  await _removeLegacyRegistryRun();
 
   if (enable) {
-    final result = await Process.run('reg', [
-      'add',
-      _startupRunKey,
-      '/v',
-      _startupValueName,
-      '/t',
-      'REG_SZ',
-      '/d',
+    // 使用 Task Scheduler ONSTART 触发器，系统启动时即运行（登录前）
+    final result = await Process.run('schtasks', [
+      '/create',
+      '/tn',
+      _taskName,
+      '/tr',
       command,
+      '/sc',
+      'ONSTART',
+      '/rl',
+      'HIGHEST',
       '/f',
     ]);
     if (result.exitCode != 0 && kDebugMode) {
-      debugPrint('Failed to register startup: ${result.stderr}');
+      debugPrint('Failed to register startup task: ${result.stderr}');
     }
   } else {
-    final result = await Process.run('reg', [
-      'delete',
-      _startupRunKey,
-      '/v',
-      _startupValueName,
+    final result = await Process.run('schtasks', [
+      '/delete',
+      '/tn',
+      _taskName,
       '/f',
     ]);
     if (result.exitCode != 0 && kDebugMode) {
-      debugPrint('Failed to unregister startup: ${result.stderr}');
+      debugPrint('Failed to remove startup task: ${result.stderr}');
     }
   }
 }

--- a/lib/core/platform/window_manager.dart
+++ b/lib/core/platform/window_manager.dart
@@ -33,8 +33,9 @@ class WindowManagerUtils {
 
       // 等待窗口准备就绪并显示
       await windowManager.waitUntilReadyToShow(windowOptions, () async {
-        // 如果 startupMinimize 为 true，则最小化窗口
-        if (ServiceManager().startupState.startupMinimize.value) {
+        // 自动启动时始终隐藏窗口（系统启动时无桌面会话）
+        if (isAutostart ||
+            ServiceManager().startupState.startupMinimize.value) {
           ServiceManager().uiState.setBackground(true);
           await windowManager.hide();
         } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,12 @@ import 'package:path/path.dart' as p;
 import 'package:astral/src/rust/frb_generated.dart';
 import 'package:astral/app.dart';
 
-void main() async {
+void main(List<String> args) async {
+  // 检测是否为自动启动
+  if (args.contains('--autostart')) {
+    isAutostart = true;
+  }
+
   // 初始化文件日志系统（Release 模式下不会创建文件）
   await FileLogger().init();
   GlobalErrorHandler.initialize();


### PR DESCRIPTION
## 变更内容

- 将 Windows 自动启动机制从注册表 `Run` 键迁移到 Task Scheduler。
- 创建 `ONSTART`、`HIGHEST` 级别的 `Astral` 计划任务，并清理旧快捷方式和注册表启动项。
- 通过 `--autostart` 参数识别自动启动场景，在桌面会话尚未就绪时保持窗口隐藏。

## 原因

注册表 `Run` 键依赖用户登录后启动，无法覆盖系统启动阶段。计划任务可以在系统启动时触发，并更适合需要提升权限的启动流程。

## 影响

改动仅作用于 Windows。关闭自动启动时会删除对应计划任务；其他平台继续跳过这套逻辑。

## 验证

- `git diff --check`：通过。
- 与 `ldoubil/astral:main` 比较：仅包含 1 个提交，修改 3 个文件（新增 46 行、删除 22 行）。
- `dart format --output=none --set-exit-if-changed ...`：未通过，3 个修改文件仍会产生格式化差异。
- 未运行完整 Flutter 分析或测试；临时检出尚未解析项目依赖。
